### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ and also more examples using other JVM languages like Clojure and JRuby.
 Assuming that you have the aws command line tools installed, you can list the contents of a crawl using:
 
 ````````
-aws ls -1 aws-publicdatasets/common-crawl/crawl-data/CC-MAIN-2013-48/  | head -6
+aws s3 ls s3://aws-publicdatasets/common-crawl/crawl-data/CC-MAIN-2014-10/ --recursive | head -6
 ````````
 
 You can copy one segment to your laptop (segment files are less than 1 gigabytes) using:
 
 ````````
-aws get aws-publicdatasets/common-crawl/crawl-data/CC-MAIN-2013-48/segments/1386163035819/warc/CC-MAIN-20131204131715-00002-ip-10-33-133-15.ec2.internal.warc.gz CC-MAIN-20131204131715-00002-ip-10-33-133-15.ec2.internal.warc.gz
+aws s3 cp s3://aws-publicdatasets/common-crawl/crawl-data/CC-MAIN-2014-10/segments/1394023864559/warc/CC-MAIN-20140305125104-00002-ip-10-183-142-35.ec2.internal.warc.gz .
 ````````
 
 Then run this example using:
@@ -50,7 +50,7 @@ public class ReadS3Bucket {
 As you can see in the example code, I pass the bucket and prefix as:
 
 ````````
-    process(s3, "aws-publicdatasets", "common-crawl/crawl-data/CC-MAIN-2013-20", 2);
+    process(s3, "aws-publicdatasets", "common-crawl/crawl-data/CC-MAIN-2014-10", 2);
 ````````
 
 Note, using the Common Crawl AMI (I run it on a Medium EC2 instance), I installed JDK 1.7 (required for

--- a/src/main/java/org/commoncrawl/examples/java_warc/ReadWARC.java
+++ b/src/main/java/org/commoncrawl/examples/java_warc/ReadWARC.java
@@ -16,7 +16,7 @@ public class ReadWARC {
     // use a callback class for handling WARC record data:
     IProcessWarcRecord processor = new SampleProcessWarcRecord();
 
-    String inputWarcFile="CC-MAIN-20131204131715-00002-ip-10-33-133-15.ec2.internal.warc.gz";
+    String inputWarcFile="CC-MAIN-20140305125104-00002-ip-10-183-142-35.ec2.internal.warc.gz";
     GZIPInputStream gzInputStream=new GZIPInputStream(new FileInputStream(inputWarcFile));
     DataInputStream inStream=new DataInputStream(gzInputStream);
 


### PR DESCRIPTION
Hi,
It seems that the usage of AWS CLI tools has changed over the past year or so, as getting a small-ish example dataset is quite useful, could you update the README with the following updates?

The changes to the 'ReadWARC.java' appear to simply mirror the README updates to a later, more current, dataset archive.
